### PR TITLE
-color_codes parameter added to improve memory

### DIFF
--- a/deepmatting_seg.lua
+++ b/deepmatting_seg.lua
@@ -22,6 +22,7 @@ cmd:option('-image_size', 512, 'Maximum height / width of generated image')
 cmd:option('-gpu', '0', 'Zero-indexed ID of the GPU to use; for CPU mode set -gpu = -1')
 cmd:option('-multigpu_strategy', '', 'Index of layers to split the network across GPUs')
 cmd:option('-laplacian', 'laplacian.csv', 'matting laplacian')
+cmd:option('-color_codes', 'blue,green,black,white,red,yellow,grey,lightblue,purple', 'Colors used in content mask')
 
 -- Optimization options
 cmd:option('-content_weight', 5e0)
@@ -157,7 +158,7 @@ local function main(params)
     local style_seg_caffe = style_seg:float()
     table.insert(style_seg_images_caffe, style_seg_caffe)
   end
-  local color_codes = {'blue', 'green', 'black', 'white', 'red', 'yellow', 'grey', 'lightblue', 'purple'}
+  local color_codes = params.color_codes:split(",")
   local color_content_masks, color_style_masks = {}, {}
   for j = 1, #color_codes do
     local content_mask_j = ExtractMask(content_seg_caffe, color_codes[j], dtype)

--- a/deepmatting_seg.lua
+++ b/deepmatting_seg.lua
@@ -21,7 +21,7 @@ cmd:option('-content_seg', 'content_seg.jpg',
 cmd:option('-image_size', 512, 'Maximum height / width of generated image')
 cmd:option('-gpu', '0', 'Zero-indexed ID of the GPU to use; for CPU mode set -gpu = -1')
 cmd:option('-multigpu_strategy', '', 'Index of layers to split the network across GPUs')
-cmd:option('-laplacian', 'laplacian.csv', 'matting laplacian')
+cmd:option('-laplacian', '', 'matting laplacian')
 cmd:option('-color_codes', 'blue,green,black,white,red,yellow,grey,lightblue,purple', 'Colors used in content mask')
 
 -- Optimization options


### PR DESCRIPTION
**The New Parameter:**

* `-color_codes`: Comma-separated list of color names that were used in the content mask.
  Default is `blue,green,black,white,red,yellow,grey,lightblue,purple`.  

Any combination and order of `blue,green,black,white,red,yellow,grey,lightblue,purple` is acceptable as input, including just a single color. 

GPU memory usage is greatly lowered when only the colors in your mask image are used, as per this issue: https://github.com/martinbenson/deep-photo-styletransfer/issues/32. The new parameter is based on the `-style_layers` parameter from [Neural-Style](https://github.com/jcjohnson/neural-style)

This new feature shouldn't change your output images and GPU usage unless you use the new parameter. 


I also removed `laplacian.csv` from the default value for the laplacian input parameter, as per the discussion in this pull request here: https://github.com/martinbenson/deep-photo-styletransfer/pull/31

